### PR TITLE
Add missing start drag method, fix issue with flickity startdrag

### DIFF
--- a/unidragger.js
+++ b/unidragger.js
@@ -150,6 +150,10 @@ proto.pointerMove = function( event, pointer ) {
   this._dragMove( event, pointer, moveVector );
 };
 
+proto._dragPointerDown = function( event, pointer ) {
+  this.pointerDownPointer = pointer;
+};
+
 // base pointer move logic
 proto._dragPointerMove = function( event, pointer ) {
   var moveVector = {


### PR DESCRIPTION
The method is undefined in flickity when running installation with npm install flickity. I got to work again by readding this method and tested on my local installation. If you accept this fix, please please update it to npm also :)