### PR TITLE
Adding the ability to configure event listener options, restoring ability to prevent preventDefault() in pointerDown

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Dragger.prototype.dragStart = function( event, pointer ) {
 };
 
 Dragger.prototype.dragMove = function( event, pointer, moveVector ) {
-  var dragX = this.dragStartPoint.x + moveVector.x;
-  var dragY = this.dragStartPoint.y + moveVector.y;
+  var dragX = moveVector.x;
+  var dragY = moveVector.y;
   this.element.style.left = dragX + 'px';
   this.element.style.top = dragY + 'px';
 };

--- a/unidragger.js
+++ b/unidragger.js
@@ -65,7 +65,7 @@ proto._bindHandles = function( isAdd ) {
   for ( var i=0; i < this.handles.length; i++ ) {
     var handle = this.handles[i];
     this._bindStartEvent( handle, isAdd );
-    handle[ bindMethod ]( 'click', this );
+    handle[ bindMethod ]( 'click', this, this.listenerOpts || false );
     // touch-action: none to override browser touch gestures. metafizzy/flickity#540
     if ( window.PointerEvent ) {
       handle.style.touchAction = touchAction;
@@ -95,7 +95,10 @@ proto.pointerDown = function( event, pointer ) {
     pageY: pointer.pageY,
   };
 
-  event.preventDefault();
+  if (this.preventDefaultOnPointerDown( event )) {
+    event.preventDefault();
+  }
+
   this.pointerDownBlur();
   // bind move and end events
   this._bindPostStartEvents( event );
@@ -119,6 +122,10 @@ var clickTypes = {
   image: true,
   file: true,
 };
+
+proto.preventDefaultOnPointerDown = function ( event ) {
+  return true
+}
 
 // dismiss inputs with text fields. flickity#403, flickity#404
 proto.okayPointerDown = function( event ) {


### PR DESCRIPTION
Follow-up from PR to Unipointer: https://github.com/metafizzy/unipointer/pull/8

Same reasoning around the need for adding `listenerOpts` applies.

I'm also hoping you reconsider leaving the ability to prevent `event.preventDefault()` in pointerDown, without actually quitting the event chain via `this.okayPointerDown()`. The main reason for allowing the event chain to continue *without* `event.preventDefault()` is to allow inner elements with `'click'` handlers a chance to fire. Prevent default in `touchstart` stops the chain and prevents these events from firing. The structure I've outlined would make this behavior opt-in, leaving the always preventing behavior the default.

Also included a minor fix in the README, which was referencing an internal property that was removed.